### PR TITLE
Remove `static`

### DIFF
--- a/SDL++/include/ray.hpp
+++ b/SDL++/include/ray.hpp
@@ -28,6 +28,6 @@ namespace SDL {
 		bool intersectRect(const Rect& rect);
 		bool intersectRect(const FRect& rect);
 
-		friend static std::ostream& operator<<(std::ostream& os, const Ray& r);
+		friend std::ostream& operator<<(std::ostream& os, const Ray& r);
 	};
 }


### PR DESCRIPTION
Operator overloads are not allowed to be static and friend functions are not allowed to have storage classes.